### PR TITLE
Ms boom fix timelex

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -115,11 +115,11 @@ class _timelex(object):
                 # First character of the token - determines if we're starting
                 # to parse a word, a number or something else.
                 token = nextchar
-                if nextchar.isalpha():
+                if self.isword(nextchar):
                     state = 'a'
-                elif nextchar.isdigit():
+                elif self.isnum(nextchar):
                     state = '0'
-                elif nextchar.isspace():
+                elif self.isspace(nextchar):
                     token = ' '
                     break  # emit token
                 else:
@@ -128,7 +128,7 @@ class _timelex(object):
                 # If we've already started reading a word, we keep reading
                 # letters until we find something that's not part of a word.
                 seenletters = True
-                if nextchar.isalpha():
+                if self.isword(nextchar):
                     token += nextchar
                 elif nextchar == '.':
                     token += nextchar
@@ -139,7 +139,7 @@ class _timelex(object):
             elif state == '0':
                 # If we've already started reading a number, we keep reading
                 # numbers until we find something that doesn't fit.
-                if nextchar.isdigit():
+                if self.isnum(nextchar):
                     token += nextchar
                 elif nextchar == '.' or (nextchar == ',' and len(token) >= 2):
                     token += nextchar
@@ -151,9 +151,9 @@ class _timelex(object):
                 # If we've seen some letters and a dot separator, continue
                 # parsing, and the tokens will be broken up later.
                 seenletters = True
-                if nextchar == '.' or nextchar.isalpha():
+                if nextchar == '.' or self.isword(nextchar):
                     token += nextchar
-                elif nextchar.isdigit() and token[-1] == '.':
+                elif self.isnum(nextchar) and token[-1] == '.':
                     token += nextchar
                     state = '0.'
                 else:
@@ -162,9 +162,9 @@ class _timelex(object):
             elif state == '0.':
                 # If we've seen at least one dot separator, keep going, we'll
                 # break up the tokens later.
-                if nextchar == '.' or nextchar.isdigit():
+                if nextchar == '.' or self.isnum(nextchar):
                     token += nextchar
-                elif nextchar.isalpha() and token[-1] == '.':
+                elif self.isword(nextchar) and token[-1] == '.':
                     token += nextchar
                     state = 'a.'
                 else:
@@ -197,9 +197,24 @@ class _timelex(object):
     def next(self):
         return self.__next__()  # Python 2.x support
 
+    @classmethod
     def split(cls, s):
         return list(cls(s))
-    split = classmethod(split)
+
+    @classmethod
+    def isword(cls, nextchar):
+        """ Whether or not the next character is part of a word """
+        return nextchar.isalpha()
+
+    @classmethod
+    def isnum(cls, nextchar):
+        """ Whether the next character is part of a number """
+        return nextchar.isdigit()
+
+    @classmethod
+    def isspace(cls, nextchar):
+        """ Whether the next character is whitespace """
+        return nextchar.isspace()
 
 
 class _resultbase(object):

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -71,12 +71,6 @@ class _timelex(object):
             instream = StringIO(instream)
 
         self.instream = instream
-        self.wordchars = ('abcdfeghijklmnopqrstuvwxyz'
-                          'ABCDEFGHIJKLMNOPQRSTUVWXYZ_'
-                          'ßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ'
-                          'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ')
-        self.numchars = '0123456789'
-        self.whitespace = ' \t\r\n'
         self.charstack = []
         self.tokenstack = []
         self.eof = False
@@ -101,9 +95,6 @@ class _timelex(object):
         seenletters = False
         token = None
         state = None
-        wordchars = self.wordchars
-        numchars = self.numchars
-        whitespace = self.whitespace
 
         while not self.eof:
             # We only realize that we've reached the end of a token when we
@@ -124,11 +115,11 @@ class _timelex(object):
                 # First character of the token - determines if we're starting
                 # to parse a word, a number or something else.
                 token = nextchar
-                if nextchar in wordchars:
+                if nextchar.isalpha():
                     state = 'a'
-                elif nextchar in numchars:
+                elif nextchar.isdigit():
                     state = '0'
-                elif nextchar in whitespace:
+                elif nextchar.isspace():
                     token = ' '
                     break  # emit token
                 else:
@@ -137,7 +128,7 @@ class _timelex(object):
                 # If we've already started reading a word, we keep reading
                 # letters until we find something that's not part of a word.
                 seenletters = True
-                if nextchar in wordchars:
+                if nextchar.isalpha():
                     token += nextchar
                 elif nextchar == '.':
                     token += nextchar
@@ -148,7 +139,7 @@ class _timelex(object):
             elif state == '0':
                 # If we've already started reading a number, we keep reading
                 # numbers until we find something that doesn't fit.
-                if nextchar in numchars:
+                if nextchar.isdigit():
                     token += nextchar
                 elif nextchar == '.' or (nextchar == ',' and len(token) >= 2):
                     token += nextchar
@@ -160,9 +151,9 @@ class _timelex(object):
                 # If we've seen some letters and a dot separator, continue
                 # parsing, and the tokens will be broken up later.
                 seenletters = True
-                if nextchar == '.' or nextchar in wordchars:
+                if nextchar == '.' or nextchar.isalpha():
                     token += nextchar
-                elif nextchar in numchars and token[-1] == '.':
+                elif nextchar.isdigit() and token[-1] == '.':
                     token += nextchar
                     state = '0.'
                 else:
@@ -171,9 +162,9 @@ class _timelex(object):
             elif state == '0.':
                 # If we've seen at least one dot separator, keep going, we'll
                 # break up the tokens later.
-                if nextchar == '.' or nextchar in numchars:
+                if nextchar == '.' or nextchar.isdigit():
                     token += nextchar
-                elif nextchar in wordchars and token[-1] == '.':
+                elif nextchar.isalpha() and token[-1] == '.':
                     token += nextchar
                     state = 'a.'
                 else:

--- a/dateutil/test/test.py
+++ b/dateutil/test/test.py
@@ -5584,6 +5584,26 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parser().parse(self.str_str),
                          parser().parse(self.uni_str))
 
+    def testParseUnicodeWords(self):
+
+        class rus_parserinfo(parserinfo):
+            MONTHS = [("янв", "Январь"),
+                      ("фев", "Февраль"),
+                      ("мар", "Март"),
+                      ("апр", "Апрель"),
+                      ("май", "Май"),
+                      ("июн", "Июнь"),
+                      ("июл", "Июль"),
+                      ("авг", "Август"),
+                      ("сен", "Сентябрь"),
+                      ("окт", "Октябрь"),
+                      ("ноя", "Ноябрь"),
+                      ("дек", "Декабрь")]
+
+        self.assertEqual(parse('10 Сентябрь 2015 10:20',
+                               parserinfo=rus_parserinfo()),
+                         datetime(2015, 9, 10, 10, 20))
+
 
 class EasterTest(unittest.TestCase):
     easterlist = [


### PR DESCRIPTION
Currently not 100% necessary since there isn't an easy interface for overriding `_timelex`, but I think for the 2.6 release we should make timelex a public interface so users can use a customized tokenizer. As such, I would prefer if there were an easy way to override the token checks.

My profiling indicates that your way is just as fast as the current way and the additional call makes the tokenizer about half as fast. I think we can revert to your way of doing things if this speed issue is a major problem, but I'm not sure that this part of the tokenizer is the bottleneck anyway.